### PR TITLE
fix workflow after repo ownership change

### DIFF
--- a/.github/workflows/full-workflow.yml
+++ b/.github/workflows/full-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Download previous test results
         if: always()
         run: |
-          python download_artifacts.py https://api.github.com/repos/guotin/flaky-test-ci/actions/artifacts ${{ secrets.GITHUB_TOKEN }} test-results-full-workflow
+          python download_artifacts.py https://api.github.com/repos/f-secure/flaky-test-ci/actions/artifacts ${{ secrets.GITHUB_TOKEN }} test-results-full-workflow
       - name: Flaky test analysis and heatmaps - grouping by 2 runs - 10 runs history
         if: always()
         uses: guotin/fliprate_actions@master


### PR DESCRIPTION
Incorrect artifact url given to `download_artifacts.py` caught my eye and here's a fix